### PR TITLE
fix(typora): fix the wrong size of h3 and h3 a

### DIFF
--- a/typora/lapis-cv.css
+++ b/typora/lapis-cv.css
@@ -100,7 +100,7 @@
 #write h4,
 #write h5,
 #write h6 {
-    font-size: var(--h3-size) - 0.5pt;
+    font-size: var(--h3-size);
 }
 
 #write h3 a,
@@ -108,7 +108,7 @@
 #write h5 a,
 #write h6 a {
     font-weight: normal;
-    font-size: var(--h3-size);
+    font-size: var(--h3-size) - 0.5pt;
 }
 
 #write .md-math-block,


### PR DESCRIPTION
According to obsidian's style, \<h3> is 10.5pt and \<h3 a> is 10pt. But in typora's style, it seems that the code "- 0.5pt" is mistakenly written to  \<h3> instead of  \<h3 a>, which leads to unexpected style differences.

<img width="485" alt="image" src="https://github.com/user-attachments/assets/7085ae10-547b-4a4e-b3bf-cc5689930d48">

<img width="390" alt="image" src="https://github.com/user-attachments/assets/5fa88aba-87bd-4882-860b-de713fbf34a3">

