### PR TITLE
fix: Fixed the issue where hyperlinks could not be selected or clicked after exporting PDF

### DIFF
--- a/styles/classic/obsidian.css
+++ b/styles/classic/obsidian.css
@@ -81,7 +81,6 @@ body {
 
 .external-link {
     background-image: none;
-    filter: brightness(1.3) hue-rotate(-10deg);
 }
 
 .markdown-rendered ul>li {

--- a/styles/main.css
+++ b/styles/main.css
@@ -169,7 +169,6 @@ p:has(.avatar, img[alt="avatar"]) {
 
 a {
     color: var(--link-color);
-    filter: brightness(1.3) hue-rotate(-10deg);
     text-decoration: none;
     font-weight: normal;
 }

--- a/styles/serif/obsidian.css
+++ b/styles/serif/obsidian.css
@@ -81,7 +81,6 @@ body {
 
 .external-link {
     background-image: none;
-    filter: brightness(1.3) hue-rotate(-10deg);
 }
 
 .markdown-rendered ul>li {


### PR DESCRIPTION
# 解决了在导出 PDF 后，超链接内容无法选中、点击跳转的非预期效果

## 修改
修改了以下文件：
- `styles/classic/obsidian.css`
- `styles/main.css`
- `styles/serif/obsidian.css`

具体修改内容：
参考了 [issue-35](https://github.com/BingyanStudio/LapisCV/issues/35#issuecomment-2890328037) 中给出的解决方案，删除了上述的三个文件中包含 `filter` 字段的 css 代码

## 本地构建后情况
使用 MSY2 构建后输出的 release 文件可正常导出可选中、点击跳转的超链接文字内容