### PR TITLE
fix: fallback to JetBrainsMono for special characters

### DIFF
--- a/styles/classic/typora.css
+++ b/styles/classic/typora.css
@@ -49,6 +49,13 @@ body,
     font-weight: bold;
 }
 
+/* Latin + Greek + Cyrillic */
+@font-face {
+    font-family: "SourceHanSansCN";
+    src: url('../fonts/JetBrainsMono-Regular.ttf');
+    unicode-range: U+00-52F, U+1E00-1FFF, U+2200-22FF;
+}
+
 @font-face {
     font-family: "JetBrainsMono";
     src: url('lapis-cv/fonts/JetBrainsMono-Regular.ttf');

--- a/styles/classic/vscode.css
+++ b/styles/classic/vscode.css
@@ -44,6 +44,13 @@
     font-weight: bold;
 }
 
+/* Latin + Greek + Cyrillic */
+@font-face {
+    font-family: "SourceHanSansCN";
+    src: url('../fonts/JetBrainsMono-Regular.ttf');
+    unicode-range: U+00-52F, U+1E00-1FFF, U+2200-22FF;
+}
+
 @font-face {
     font-family: "JetBrainsMono";
     src: url('../fonts/JetBrainsMono-Regular.ttf');

--- a/styles/serif/typora.css
+++ b/styles/serif/typora.css
@@ -49,10 +49,24 @@ body,
     font-weight: bold;
 }
 
+/* Latin + Greek + Cyrillic */
+@font-face {
+    font-family: "SourceHanSansCN";
+    src: url('../fonts/JetBrainsMono-Regular.ttf');
+    unicode-range: U+00-52F, U+1E00-1FFF, U+2200-22FF;
+}
+
 @font-face {
     font-family: "SourceHanSerifCN";
     src: url('lapis-cv/fonts/SourceHanSerifCN-Bold.ttf');
     font-weight: bold;
+}
+
+/* Latin + Greek + Cyrillic */
+@font-face {
+    font-family: "SourceHanSerifCN";
+    src: url('../fonts/JetBrainsMono-Regular.ttf');
+    unicode-range: U+00-52F, U+1E00-1FFF, U+2200-22FF;
 }
 
 @font-face {

--- a/styles/serif/vscode.css
+++ b/styles/serif/vscode.css
@@ -46,10 +46,24 @@
     font-weight: bold;
 }
 
+/* Latin + Greek + Cyrillic */
+@font-face {
+    font-family: "SourceHanSansCN";
+    src: url('../fonts/JetBrainsMono-Regular.ttf');
+    unicode-range: U+00-52F, U+1E00-1FFF, U+2200-22FF;
+}
+
 @font-face {
     font-family: "SourceHanSerifCN";
     src: url('../fonts/SourceHanSerifCN-Bold.ttf');
     font-weight: bold;
+}
+
+/* Latin + Greek + Cyrillic */
+@font-face {
+    font-family: "JetBrainsMonoSpecial";
+    src: url('../fonts/JetBrainsMono-Regular.ttf');
+    unicode-range: U+00-52F, U+1E00-1FFF, U+2200-22FF;
 }
 
 @font-face {

--- a/styles/serif/vscode.css
+++ b/styles/serif/vscode.css
@@ -60,11 +60,6 @@
 }
 
 /* Latin + Greek + Cyrillic */
-@font-face {
-    font-family: "JetBrainsMonoSpecial";
-    src: url('../fonts/JetBrainsMono-Regular.ttf');
-    unicode-range: U+00-52F, U+1E00-1FFF, U+2200-22FF;
-}
 
 @font-face {
     font-family: "JetBrainsMono";

--- a/styles/serif/vscode.css
+++ b/styles/serif/vscode.css
@@ -60,6 +60,11 @@
 }
 
 /* Latin + Greek + Cyrillic */
+@font-face {
+    font-family: "SourceHanSerifCN";
+    src: url('../fonts/JetBrainsMono-Regular.ttf');
+    unicode-range: U+00-52F, U+1E00-1FFF, U+2200-22FF;
+}
 
 @font-face {
     font-family: "JetBrainsMono";


### PR DESCRIPTION
fix https://github.com/BingyanStudio/LapisCV/issues/49

Fallback to JetBrainsMono font when displaying Latin, Greek and Cyrillic characters.